### PR TITLE
Fix frame counter

### DIFF
--- a/demuxer/src/pes.ts
+++ b/demuxer/src/pes.ts
@@ -95,7 +95,6 @@ export function decode_pes(
     len -= hlen;
 
     s.stream_id = stream_id;
-    s.frame_num++;
   }
 
   if (s.stream_id && s.content_type !== content_types.unknown) {

--- a/demuxer/src/stream.ts
+++ b/demuxer/src/stream.ts
@@ -108,6 +108,7 @@ export class Stream {
       // finalize previously accumulated packet
       const packet = this.finalize();
       // start new packet
+      this.frame_num++;
       this.payload = {
         buffer: [data],
         buflen: len,


### PR DESCRIPTION
Currently all packets have an incorrect `frame_num`, except those emitted after `demuxer.finalize()`
It is more correct to increment `frame_num` after finalizing the previous accumulated packet.